### PR TITLE
Provide opts to nvim_set_keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ You can also bind the function `forward` and `backward` as followed
 
 ```
 local opts = { silent=true, noremap=true }
-vim.api.nvim_set_keymap("n", "<M-o>", ":lua require('bufjump').backward()<cr>")
-vim.api.nvim_set_keymap("n", "<M-i>", ":lua require('bufjump').forward()<cr>")
+vim.api.nvim_set_keymap("n", "<M-o>", ":lua require('bufjump').backward()<cr>", opts)
+vim.api.nvim_set_keymap("n", "<M-i>", ":lua require('bufjump').forward()<cr>", opts)
 ```
 
 ### on_success


### PR DESCRIPTION
opts is being declared but not provided to `nvim_set_keymap` on the docs

Your plugin is exactly what I was looking for!
Thank you so much!