### PR TITLE
feat: add more generic condition jump

### DIFF
--- a/.luarc.jsonc
+++ b/.luarc.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "runtime": {
+    "version": "LuaJIT"
+  },
+  "workspace": {
+    "library": [
+      "$VIMRUNTIME/lua",
+      "${3rd}/luv/library"
+    ]
+  },
+}
+

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "Input"

--- a/lua/bufjump.lua
+++ b/lua/bufjump.lua
@@ -132,6 +132,7 @@ local setup = function(cfg)
   if cfg.backward_same_buf_key then
     vim.keymap.set("n", cfg.backward_same_buf_key, bufjump.backward_same_buf)
   end
+  on_success = cfg.on_success or nil
 end
 
 return {

--- a/lua/bufjump.lua
+++ b/lua/bufjump.lua
@@ -3,11 +3,11 @@ local M = {}
 local on_success = nil
 
 local jumpbackward = function(num)
-  vim.cmd([[execute "normal! ]] .. tostring(num) .. [[\<c-o>"]])
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(tostring(num) .. "<c-o>", true, true, true), "n", false)
 end
 
 local jumpforward = function(num)
-  vim.cmd([[execute "normal! ]] .. tostring(num) .. [[\<c-i>"]])
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(tostring(num) .. "<c-i>", true, true, true), "n", false)
 end
 
 ---@param stop_cond fun(from_bufnr: integer, to_bufnr: integer):boolean

--- a/lua/bufjump.lua
+++ b/lua/bufjump.lua
@@ -49,7 +49,7 @@ M.forward_cond = function(stop_cond)
   local getjumplist = vim.fn.getjumplist()
   local jumplist, from_pos = getjumplist[1], getjumplist[2] + 1
   local max_pos = #jumplist
-  if max_pos == 0 or from_pos == max_pos then
+  if max_pos == 0 or from_pos >= max_pos then
     return
   end
 

--- a/lua/bufjump.lua
+++ b/lua/bufjump.lua
@@ -89,7 +89,6 @@ local forward = function()
   end
 end
 
-
 local forward_same_buf = function()
   local jumplistAndPos = vim.fn.getjumplist()
   local jumplist = jumplistAndPos[1]
@@ -117,7 +116,7 @@ local forward_same_buf = function()
 end
 
 local setup = function(cfg)
-  local bufjump = require('bufjump')
+  local bufjump = require("bufjump")
   cfg = cfg or {}
   if cfg.forward_key ~= false then
     local forward_key = cfg.forward_key or "<C-n>"

--- a/lua/bufjump.lua
+++ b/lua/bufjump.lua
@@ -1,3 +1,5 @@
+local M = {}
+
 local on_success = nil
 
 local jumpbackward = function(num)
@@ -8,7 +10,7 @@ local jumpforward = function(num)
   vim.cmd([[execute "normal! ]] .. tostring(num) .. [[\<c-i>"]])
 end
 
-local backward = function()
+M.backward = function()
   local getjumplist = vim.fn.getjumplist()
   local jumplist = getjumplist[1]
   if #jumplist == 0 then
@@ -33,7 +35,7 @@ local backward = function()
   end
 end
 
-local backward_same_buf = function()
+M.backward_same_buf = function()
   local jumplistAndPos = vim.fn.getjumplist()
 
   local jumplist = jumplistAndPos[1]
@@ -60,7 +62,7 @@ local backward_same_buf = function()
   end
 end
 
-local forward = function()
+M.forward = function()
   local getjumplist = vim.fn.getjumplist()
   local jumplist = getjumplist[1]
   if #jumplist == 0 then
@@ -89,7 +91,7 @@ local forward = function()
   end
 end
 
-local forward_same_buf = function()
+M.forward_same_buf = function()
   local jumplistAndPos = vim.fn.getjumplist()
   local jumplist = jumplistAndPos[1]
   if #jumplist == 0 then
@@ -115,7 +117,7 @@ local forward_same_buf = function()
   end
 end
 
-local setup = function(cfg)
+M.setup = function(cfg)
   local bufjump = require("bufjump")
   cfg = cfg or {}
   if cfg.forward_key ~= false then
@@ -135,10 +137,4 @@ local setup = function(cfg)
   on_success = cfg.on_success or nil
 end
 
-return {
-  backward = backward,
-  forward = forward,
-  backward_same_buf = backward_same_buf,
-  forward_same_buf = forward_same_buf,
-  setup = setup,
-}
+return M


### PR DESCRIPTION
To show how it work, current jump functions can be implmented in a more clear way:
```lua
M.backward = function()
  M.backward_cond(function(from_bufnr, to_bufnr)
    return from_bufnr ~= to_bufnr and vim.api.nvim_buf_is_valid(to_bufnr)
  end)
end

M.backward_same_buf = function()
  local jumplistAndPos = vim.fn.getjumplist()
  M.backward_cond(function(from_bufnr, to_bufnr)
    return from_bufnr == to_bufnr and vim.api.nvim_buf_is_valid(to_bufnr)
  end)
end
```

Still wip, and finally this will allow various customizable useful jumps, e.g.:
* jump between buffers with the same filetype
* jump within fixed range of lines
* ....
