### PR TITLE
fix: on_success is ignored in the setup

### DIFF
--- a/lua/bufjump.lua
+++ b/lua/bufjump.lua
@@ -133,6 +133,9 @@ local setup = function(cfg)
   if cfg.backward_same_buf_key then
     vim.keymap.set("n", cfg.backward_same_buf_key, bufjump.backward_same_buf)
   end
+  if cfg.on_success then
+    on_success = cfg.on_success
+  end
 end
 
 return {


### PR DESCRIPTION
on_success function passed by the user seems to be ignored in the setup (example from readme). 